### PR TITLE
bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fc-toolkit",
-  "version": "1.1.0",
+  "version": "1.1.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -229,6 +229,19 @@
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
       "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA=="
+    },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+    },
+    "@types/lodash.omitby": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.omitby/-/lodash.omitby-4.6.6.tgz",
+      "integrity": "sha512-bHkWp4YyTlqPtHgUwEhExcMQNb8V+HjTUzhxgdnw0UhuT0i61aff6RuSlXt4MbQVPJhB/24tb4WBZJQ+LYIQgw==",
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/node": {
       "version": "8.10.21",
@@ -4823,6 +4836,11 @@
       "version": "4.0.6",
       "resolved": "http://registry.npm.taobao.org/lodash.isplainobject/download/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E="
     },
     "lodash.set": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fc-toolkit",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "description": "fc-toolkit",
   "license": "MIT",
   "repository": "",
@@ -39,10 +39,12 @@
     "filesize": "^6.0.0",
     "lodash.isnil": "^4.0.0",
     "lodash.isplainobject": "^4.0.6",
+    "lodash.omitby": "^4.6.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@types/jest": "^22.0.1",
+    "@types/lodash.omitby": "^4.6.6",
     "@types/node": "^8.0.0",
     "coveralls": "^2.0.0",
     "jest": "^22.0.4",

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -16,7 +16,6 @@ export type initInvokerResult = (
 export function initInvoker(options: IInitInvokerOptions): initInvokerResult {
   const invoke = bufferSupport.initInvoker({
     ...options,
-    bufferOssResp: false,
   });
   return (serviceName: string, functionName: string, body: any) =>
     invoke(serviceName, functionName, body).then(res => res.toString());

--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -2,7 +2,9 @@ import * as bufferSupport from './bufferSupport/receiver';
 
 export type AliyunCallback = bufferSupport.AliyunCallback;
 export type OSS_TYPE = bufferSupport.OSS_TYPE;
-export type IPayloadObject = bufferSupport.IPayloadObject;
+export interface IPayloadObject {
+  [index: string]: any;
+}
 
 export type IReceiveParsedPayload = bufferSupport.IReceiveParsedPayload;
 export type IReplyPayload = bufferSupport.IReplyPayload;
@@ -20,11 +22,7 @@ export function initReceiver(
 
   return {
     receive: (event: string | IReceiveParsedPayload) =>
-      receive(event).then(
-        res => (Buffer.isBuffer(res) ? JSON.parse(res.toString()) : res)
-      ),
+      receive(event).then(res => JSON.parse(res.body.toString())),
     reply,
   };
-
-  return { receive, reply };
 }


### PR DESCRIPTION
把storageClient.get替换为getAsBuffer

调用bufferSupport包装的initInvoker和initReceiver时, 如果发送的是buffer, 收到的也是buffer (不论是invoke发送参数还是reply发送结果)

原先的两个接口保持不变