### PR TITLE
chore: don't parse resp body get from oss

### DIFF
--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -16,18 +16,7 @@ export function initReceiver(
 
   return {
     receive: (event: string | IReceiveParsedPayload) =>
-      receive(event).then(res => {
-        if (res.storeType === 'oss') {
-          try {
-            const body = JSON.parse(res.body);
-            return body;
-          } catch (err) {
-            throw new Error(`Parse object content error: ${err.message}`);
-          }
-        }
-
-        return res.body;
-      }),
+      receive(event).then(res => res.body),
     reply,
   };
 }


### PR DESCRIPTION
从对象存储上获取数据后，不做 JSON.parse 处理，直接返回，交给业务逻辑自己处理。这样既可支持 json 字符串，也可以支持其他序列化格式

breaking change, 准备发个大版本